### PR TITLE
Template script changes for patch 1.6

### DIFF
--- a/MicroPatches/Editor/Assets/Code/GameCore/Editor/Blueprints/BlueprintReferenceDrawer.cs
+++ b/MicroPatches/Editor/Assets/Code/GameCore/Editor/Blueprints/BlueprintReferenceDrawer.cs
@@ -1,0 +1,148 @@
+﻿#if UNITY_EDITOR
+using System;
+using Code.Framework.Utility.DotNetExtensions;
+using Code.Utility.Attributes;
+using Kingmaker.Blueprints;
+using Kingmaker.Blueprints.JsonSystem.EditorDatabase;
+using Kingmaker.Blueprints.JsonSystem.PropertyUtility;
+using Kingmaker.Code.Editor.Utility;
+using Kingmaker.Editor.UIElements.Custom.Properties;
+using Kingmaker.Editor.Utility;
+using Kingmaker.Utility.CodeTimer;
+using Owlcat.Editor.Utility;
+using Owlcat.Runtime.Core.Utility;
+using RectEx;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+#region MicroPatches
+using Kingmaker.Blueprints.Base;
+
+namespace Kingmaker.Editor.Blueprints
+{
+	//[CustomPropertyDrawer(typeof(BlueprintReference<>), true)]
+	[CustomPropertyDrawer(typeof(IReferenceBase), true)]
+#endregion
+	public class BlueprintReferenceDrawer : PropertyDrawer
+	{
+		public override VisualElement CreatePropertyGUI(SerializedProperty property)
+    	{
+             bool inline = fieldInfo.HasAttribute<InlineBlueprintAttribute>();
+             if (!inline && property.IsArrayElement())
+             {
+                 var parent = property.GetParent();
+                 if (parent != null)
+                 {
+                     var parentField = FieldFromProperty.GetFieldInfo(parent);
+                     inline = parentField?.HasAttribute<InlineBlueprintAttribute>() ?? false;
+                 }
+             }
+             
+             return new BlueprintReferenceProperty(property, fieldInfo, inline);
+         }
+
+		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			return EditorGUIUtility.singleLineHeight;
+		}
+
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			EditorGUI.BeginProperty(position, label, property);
+			Type referencedType;
+
+			var fieldType = fieldInfo.FieldType;
+			if ((fieldInfo.FieldType.IsGenericType && 
+			     fieldInfo.FieldType.GetGenericTypeDefinition() == typeof(BlueprintReference<>)) || 
+			    fieldType.IsArrayOfType(typeof(BlueprintReference<>)))
+			{
+				var genericType = fieldType;
+				while (true)
+				{
+					if (genericType.IsArray)
+					{
+						var elementType = genericType.GetElementType();
+						if (elementType != null)
+						{
+							genericType = elementType;
+							continue;
+						}
+					}
+
+					if (genericType.IsList())
+					{
+						var elementType = genericType.GenericTypeArguments[0];
+						if (elementType != null)
+						{
+							genericType = elementType;
+							continue;
+						}
+					}
+
+					break;
+				}
+
+				referencedType = genericType.IsGenericType &&
+				                 genericType.GetGenericTypeDefinition() == typeof(BlueprintReference<>) ? 
+					genericType.GenericTypeArguments[0] : genericType;
+			}
+			else
+			{
+				var type = BlueprintLinkDrawer.GetElementType(fieldInfo?.FieldType) ?? fieldInfo?.FieldType;
+
+				referencedType = type?.BaseType?.GetGenericArguments()[0];
+			}
+
+			/*var idProperty = property.FindPropertyRelative(nameof(WeakResourceLink.AssetId));
+			var idPropertySafe = new RobustSerializedProperty(idProperty);*/
+			
+			//var type = BlueprintLinkDrawer.GetElementType(fieldInfo?.FieldType) ?? fieldInfo?.FieldType;
+			//
+			// var referencedType = type?.BaseType?.GetGenericArguments()[0];
+
+			if (referencedType == null)
+			{
+				EditorGUI.LabelField(position, property.displayName, "[Cannot determine reference type]");
+				return;
+			}
+			
+			GUILayout.BeginHorizontal();
+
+			var guidProperty = property.FindPropertyRelative("guid");
+			if (guidProperty != null)
+			{
+				var guidProp = new RobustSerializedProperty(guidProperty);
+				string g = guidProp.Property.stringValue;
+				var bp = BlueprintsDatabase.LoadById<BlueprintScriptableObject>(g);
+				var chunkPositions = position.Row(new[] { 5f, 0.1f });
+
+				using (ProfileScope.New("ShowObjectField"))
+				{
+					BlueprintPicker.ShowObjectField(chunkPositions[0], bp, g, bp2 =>
+					{
+						guidProp.Property.stringValue = bp2?.AssetGuid ?? "";
+						guidProp.Property.serializedObject.ApplyModifiedProperties();
+					}, label, referencedType, fieldInfo, referencedType);
+				}
+
+				if (guidProp.Property.boxedValue.ToString() != "" && 
+				    GUI.Button(chunkPositions[1], "", OwlcatEditorStyles.Instance.OpenButton))
+				{
+					BlueprintInspectorWindow.OpenFor(bp);
+				}
+			}
+			else
+			{
+				if (fieldInfo.HasAttribute<SerializeReference>())
+				{
+					EditorGUI.LabelField(position, label, new GUIContent("DON'T USE [SerializeReference]"));
+					PFLog.Default.Error("Don't use [SerializeReference] for BlueprintRef<>!");
+				}
+			}
+
+			GUILayout.EndHorizontal();
+			EditorGUI.EndProperty();
+		}
+    }
+}
+#endif

--- a/MicroPatches/Editor/Assets/Code/GameCore/Editor/Blueprints/ProjectView/BlueprintProjectView.cs
+++ b/MicroPatches/Editor/Assets/Code/GameCore/Editor/Blueprints/ProjectView/BlueprintProjectView.cs
@@ -13,6 +13,7 @@ using Kingmaker.Editor.Blueprints;
 using Kingmaker.Editor.Blueprints.ProjectView;
 using Kingmaker.Editor.Cutscenes;
 using Kingmaker.Editor.NodeEditor.Window;
+using Kingmaker.Editor.UIElements.ValuePicker;
 using Owlcat.Editor.Core.Utility;
 using Owlcat.Editor.Utility;
 using UnityEditor;

--- a/MicroPatches/Editor/Assets/Code/GameCore/Editor/Blueprints/WeakLinkDrawer.cs
+++ b/MicroPatches/Editor/Assets/Code/GameCore/Editor/Blueprints/WeakLinkDrawer.cs
@@ -1,26 +1,30 @@
 ﻿using System;
+using System.Linq;
 using JetBrains.Annotations;
+using Kingmaker.Code.Editor.Utility;
+using Kingmaker.Editor.UIElements.Custom.Properties;
+using Kingmaker.Editor.UIElements.ValuePicker;
 using Kingmaker.Editor.Utility;
 using Kingmaker.ResourceLinks;
-#region MicroPatches
-using Kingmaker.Code.Editor.Utility;
-#endregion
 using Owlcat.Editor.Core.Utility;
+using Owlcat.QA.Validation;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.UIElements;
 using UnityEngine.Video;
 using Object = UnityEngine.Object;
 
 namespace Kingmaker.Editor.Blueprints
 {
-	public class WeakLinkDrawer<TAsset> : PropertyDrawer 
-		where TAsset : Object
+	public class WeakLinkDrawer<TAsset> : PropertyDrawer where TAsset : Object
 	{
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
 			var idProperty = property.FindPropertyRelative(nameof(WeakResourceLink.AssetId));
+			bool notNull = property.GetAttributes()?.Any(x => x is NotNullAttribute or ValidateNotNullAttribute) ?? false;
 			var idPropertySafe = new RobustSerializedProperty(idProperty);
-			var currentValue = GetAsset(idProperty.hasMultipleDifferentValues?null:idProperty.stringValue);
+			var currentValue = GenericWeakLinkDrawer.GetAsset(idProperty.hasMultipleDifferentValues ? 
+				null : idProperty.stringValue, typeof(TAsset));
 
             #region MicroPatches
             if (currentValue == null)
@@ -34,68 +38,45 @@ namespace Kingmaker.Editor.Blueprints
             }
 			#endregion
 
-            Action<Object> pickCallback =
-				o =>
+			Action<Object> pickCallback = o =>
 				{
 					var p = idPropertySafe.Property;
 					using (GuiScopes.UpdateObject(p.serializedObject))
 					{
-						idPropertySafe.Property.stringValue = GetGuid(o);
+						idPropertySafe.Property.stringValue = GenericWeakLinkDrawer.GetGuid(o, typeof(TAsset));
 					}
 				};
 
+			var prevColor = GUI.color;
+			if (notNull && currentValue == null)
+				GUI.color = Color.red;
+			
 			AssetPicker.ShowPropertyField(
 				position, property, fieldInfo,
 				currentValue, pickCallback, 
-				label, typeof(TAsset)
+				label, typeof(TAsset), Filter
 			);
+			GUI.color = prevColor;
 		}
 
-		[CanBeNull]
-		private static Object GetAsset(string guid)
+		protected virtual bool Filter(AssetPicker.HierarchyEntry entry) => true; 
+		
+		public override VisualElement CreatePropertyGUI(SerializedProperty property)
 		{
-			if (string.IsNullOrEmpty(guid))
-				return null;
-
-			var assetPath = AssetDatabase.GUIDToAssetPath(guid);
-			if (string.IsNullOrEmpty(assetPath))
-				return null;
-
-			return AssetDatabase.LoadAssetAtPath<TAsset>(assetPath);
-		}
-
-		private static string GetGuid(Object asset)
-		{
-			if (typeof(MonoBehaviour).IsAssignableFrom(typeof(TAsset)))
-			{
-                if (!(asset is TAsset))
-                {
-                    var go = asset as GameObject;
-                    if (go == null)
-                    {
-                        return "";
-                    }
-
-                    if (go.GetComponent<TAsset>() == null)
-                    {
-                        return "";
-                    }
-                }
-            }
-
-			var assetPath = AssetDatabase.GetAssetPath(asset);
-			return AssetDatabase.AssetPathToGUID(assetPath);
-		}
+			return new WeakLinkProperty(property, typeof(TAsset), fieldInfo, Filter);
+		}	
 	}
 
 	[CustomPropertyDrawer(typeof(Texture2DLink))]
 	public class Texture2DLinkDrawer : WeakLinkDrawer<Texture2D>
 	{
 	}
+	
 	[CustomPropertyDrawer(typeof(SpriteLink))]
 	public class SpriteLinkDrawer : WeakLinkDrawer<Sprite>
 	{
 	}
+	
 	[CustomPropertyDrawer(typeof(MaterialLink))]
 	public class MaterialLinkDrawer : WeakLinkDrawer<Material>
 	{
@@ -105,5 +86,4 @@ namespace Kingmaker.Editor.Blueprints
 	public class VideoLinkDrawer : WeakLinkDrawer<VideoClip>
 	{
 	}
-
 }

--- a/MicroPatches/Editor/Assets/Code/GameCore/Editor/Validation/JsonReferenceExtractor.cs
+++ b/MicroPatches/Editor/Assets/Code/GameCore/Editor/Validation/JsonReferenceExtractor.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Kingmaker.Blueprints;
+using Kingmaker.Blueprints.JsonSystem.EditorDatabase;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+
+namespace Kingmaker.Editor.Validation
+{
+    public class JsonReferenceExtractor
+    {
+        private string m_ScriptGuid;
+        private string m_ObjectName;
+        private List<ObjRef> m_Refs;
+        
+        public string ScriptGuid => m_ScriptGuid;
+
+        public string ObjectName => m_ObjectName;
+
+        public List<ObjRef> Refs => m_Refs;
+
+        public void ParseFile(string path, Action onAssetParsed, bool checkWeakResourceLinks)
+        {
+            #region Micropatches
+			var longPath = @"\\?\" + Path.GetFullPath(path);
+			var jo = JObject.Parse(File.ReadAllText(longPath));
+			//var jo = JObject.Parse(File.ReadAllText(path));
+			#endregion
+            var root = (JObject)jo["Data"];
+            m_ScriptGuid = root["$type"].Value<string>();
+            m_ScriptGuid = m_ScriptGuid.Substring(0, 32); // value is <guid>, <typename> - cut that last part
+            m_ObjectName = Path.GetFileNameWithoutExtension(path);
+            m_Refs = new List<ObjRef>();
+            ParseJsonObject(root, onAssetParsed, checkWeakResourceLinks);
+            onAssetParsed?.Invoke();
+        }
+
+        private void ParseJsonObject(JObject root, Action onAssetParsed, bool checkWeakResourceLinks)
+        {
+            // if we have name and type, this is an internal object (component, element)
+            var np = root["name"];
+            var tp = root["$type"];
+
+            var isNestedAsset = np != null && tp != null;
+            var oldScript = m_ScriptGuid;
+            var oldName = m_ObjectName;
+            var oldRefs = m_Refs;
+            
+            if (isNestedAsset)
+            {
+                m_ScriptGuid = tp.Value<string>().Substring(0, 32);
+                m_ObjectName = np.Value<string>();
+                m_Refs = new List<ObjRef>();
+            }
+
+            foreach (var prop in root)
+            {
+                ParseValue(prop.Key, prop.Value, onAssetParsed, checkWeakResourceLinks);
+            }
+
+            if (isNestedAsset)
+            {
+                onAssetParsed?.Invoke();
+                m_ScriptGuid = oldScript;
+                m_ObjectName = oldName;
+                m_Refs = oldRefs;
+            }
+        }
+        
+        private void ParseValue(string propName, JToken value, Action onAssetParsed, bool checkWeakResourceLinks)
+        {
+            switch (value)
+            {
+                case JValue v:
+                {
+                    var s = v.Value<string>();
+                
+                    if(string.IsNullOrEmpty(s))
+                        break;
+                
+                    if (s.StartsWith("!bp_"))
+                    {
+                        // this is a blueprint link
+                        Refs.Add(new ObjRef(RefType.Asset, s.Substring(4)));
+                    }
+                    else if (propName == "_entity_id")
+                    {
+                        // this is a scene obj link
+                        Refs.Add(new ObjRef(RefType.SceneObject, s));
+                    }
+
+                    break;
+                }
+                case JObject jo:
+                    ParseJsonObject(jo, onAssetParsed, checkWeakResourceLinks);
+                    break;
+                case JArray ja:
+                {
+                    foreach (var token in ja)
+                    {
+                        ParseValue("", token, onAssetParsed, checkWeakResourceLinks);
+                    }
+
+                    break;
+                }
+            }
+        }
+        
+        [MenuItem("BP/Test refparse")]
+        public static void Test()
+        {
+            var bp = BlueprintEditorWrapper.Unwrap<SimpleBlueprint>(Selection.activeObject);
+            if (bp != null)
+            {
+                var rf = new JsonReferenceExtractor();
+                rf.ParseFile(BlueprintsDatabase.GetAssetPath(bp), () => 
+                {
+                    PFLog.Default.Log($"Parsed {rf.ObjectName}: {rf.ScriptGuid}");
+                    foreach (var objRef in rf.Refs)
+                    {
+                        PFLog.Default.Log($"referenced: {objRef.Guid} ({Path.GetFileNameWithoutExtension(BlueprintsDatabase.IdToPath(objRef.Guid))}), {objRef.RefType}");
+                    }
+                }, false);
+            }
+        }
+    }
+}

--- a/MicroPatches/Editor/Assets/Code/GameCore/Editor/Validation/ReferenceGraph.cs
+++ b/MicroPatches/Editor/Assets/Code/GameCore/Editor/Validation/ReferenceGraph.cs
@@ -161,9 +161,9 @@ namespace Kingmaker.Editor.Validation
         #region MicroPatches
         //static ReferenceGraph()
         //{
-        //    BlueprintsDatabase.OnPreSave += id => Graph?.CleanReferencesInBlueprintWithId(id);
-        //    BlueprintsDatabase.OnSavedId += id => Graph?.ParseFileWithId(id);
-        //    IsReferenceTrackingSuppressed = EditorPreferences.Instance.SuppressReferenceTracking;
+        //    BlueprintsDatabase.OnPreSave +=  Graph.CleanReferencesInBlueprintWithId;
+        //    BlueprintsDatabase.OnSavedId += Graph.ParseFileWithId;
+        //   IsReferenceTrackingSuppressed = EditorPreferences.Instance.SuppressReferenceTracking;
         //}
 
         static ReferenceGraph()
@@ -357,8 +357,8 @@ namespace Kingmaker.Editor.Validation
                             Entries.Add(
                                 new Entry
                                 {
-                                    ObjectGuid = pair.Item1,
-                                    ObjectName = Path.GetFileNameWithoutExtension(pair.Item2),
+                                    ObjectGuid = pair.Guid,
+                                    ObjectName = Path.GetFileNameWithoutExtension(pair.Path),
                                     ObjectType = data.Type.Name,
                                     References = new List<Ref>()
                                 });
@@ -378,7 +378,9 @@ namespace Kingmaker.Editor.Validation
         public void CollectPotentialBlueprints()
         {
             // todo: maybe just FindFiles will be better?
-            m_ReferencingBlueprintPaths = BlueprintsDatabase.SearchByType(typeof(SimpleBlueprint)).Select(p=>p.Item2).ToList();
+            m_ReferencingBlueprintPaths = BlueprintsDatabase.SearchByType(typeof(SimpleBlueprint))
+                .Select(p=>p.Path)
+                .ToList();
         }
         
         public void CollectPotentialScenes()

--- a/MicroPatches/Editor/Assets/Editor/Build/ShaderPreprocessor.cs
+++ b/MicroPatches/Editor/Assets/Editor/Build/ShaderPreprocessor.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using UnityEditor.Build;
+using UnityEditor.Rendering;
+using UnityEngine;
+#region MicroPatches
+using UnityEditor;
+#endregion
+
+namespace OwlcatModification.Editor.Build
+{
+	public class ShaderPreprocessor : IPreprocessShaders
+	{
+		public int callbackOrder
+			=> 0;
+
+		public void OnProcessShader(Shader shader, ShaderSnippetData snippet, IList<ShaderCompilerData> data)
+		{
+			#region MicroPatches
+            var path = AssetDatabase.GetAssetPath(shader);
+            var name = shader.name;
+
+            if (name != null && !name.Contains("Hidden/VFX"))
+                {
+                    data.Clear();
+                }
+				else
+				{
+					Debug.Log($"Found VFX shader {name} ({path}), compiling");
+				}
+			#endregion
+		}
+	}
+}

--- a/MicroPatches/Editor/Assets/Editor/Build/Tasks/PrepareBundles.cs
+++ b/MicroPatches/Editor/Assets/Editor/Build/Tasks/PrepareBundles.cs
@@ -54,6 +54,15 @@ namespace OwlcatModification.Editor.Build.Tasks
 			{
 				string assetPath = AssetDatabase.GUIDToAssetPath(assetGuid);
 				string bundleName = m_LayoutManager.GetBundleForAssetPath(assetPath, m_ModificationParameters.TargetFolderName);
+				
+				#region MicroPatches
+				if (File.GetAttributes(assetPath).HasFlag(FileAttributes.Directory))
+				{
+					// The template tries to treat subfolders in the Content folder as assets, causing an error, so skip them.
+					continue;
+				}
+				#endregion
+				
 				if (bundleName == null)
 				{
                     #region MicroPatches


### PR DESCRIPTION
- Updated some template scripts that have changed since 1.4/1.5 via ADDB/Kuru/Julia-bee
- Added support for mod Content subfolders (`Assets\Editor\Build\Tasks\PrepareBundles.cs`) via Kuru
- Added support for including VFX shaders in mod bundles (`Assets\Editor\Build\ShaderPreprocessor.cs`) via Kuru
- Added handling for long paths (`Assets\Code\GameCore\Editor\Validation\JsonReferenceExtractor.cs`) via ADDB